### PR TITLE
Fix issue when running destroy

### DIFF
--- a/autospotting-policy.json
+++ b/autospotting-policy.json
@@ -21,7 +21,8 @@
         "iam:PassRole",
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "cloudformation:DescribeStacks"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -3,6 +3,7 @@ output "function_name" {
     concat(
       aws_lambda_function.autospotting.*.function_name,
       aws_lambda_function.autospotting_from_s3.*.function_name,
+      "",
     ),
     0,
   )
@@ -13,6 +14,7 @@ output "arn" {
     concat(
       aws_lambda_function.autospotting.*.arn,
       aws_lambda_function.autospotting_from_s3.*.arn,
+      "",
     ),
     0,
   )

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -3,7 +3,7 @@ output "function_name" {
     concat(
       aws_lambda_function.autospotting.*.function_name,
       aws_lambda_function.autospotting_from_s3.*.function_name,
-      "",
+      [""],
     ),
     0,
   )
@@ -14,7 +14,7 @@ output "arn" {
     concat(
       aws_lambda_function.autospotting.*.arn,
       aws_lambda_function.autospotting_from_s3.*.arn,
-      "",
+      [""],
     ),
     0,
   )


### PR DESCRIPTION
With the upgrade to TF 0.12 the behaviour of coalesce changed a little bit and this can become problematic while running a destroy.

The changes in this PR to the coalesce fix these errors while running a destroy.