### PR TITLE
Package path default method update

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -3,12 +3,16 @@ module "label" {
   context = var.label_context
 }
 
+locals {
+  lambda_zipname = var.lambda_zipname == "" ? "${path.module}/package/autospotting.zip" : var.lambda_zipname  
+}
+
 resource "aws_lambda_function" "autospotting" {
   count = var.lambda_s3_bucket == "" ? 1 : 0
 
   function_name    = module.label.id
-  filename         = var.lambda_zipname
-  source_code_hash = filebase64sha256(var.lambda_zipname)
+  filename         = local.lambda_zipname
+  source_code_hash = filebase64sha256(local.lambda_zipname)
   role             = var.lambda_role_arn
   runtime          = var.lambda_runtime
   timeout          = var.lambda_timeout

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ EOF
 # Lambda configuration
 variable "lambda_zipname" {
   description = "Name of the archive, relative to the module"
-  default     = "package/autospotting.zip"
+  default     = ""
 }
 
 variable "lambda_s3_bucket" {


### PR DESCRIPTION
Hi, i tried to run the latest Version available on the module registry at https://registry.terraform.io/modules/AutoSpotting/autospotting/aws/0.1.1

and i recognized that the reference to the pre-build binary package might be not correct. I received the following error message during terraform plan:

```
Error: Error in function call

  on .terraform/modules/autospotting/modules/lambda/main.tf line 11, in resource "aws_lambda_function" "autospotting":
  11:   source_code_hash = filebase64sha256(var.lambda_zipname)
    |----------------
    | var.lambda_zipname is "package/autospotting.zip"

Call to function "filebase64sha256" failed: no file exists at
package/autospotting.zip.
```

My PR should fix this behavior.