### PR TITLE
Fix lambda creation bug

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -4,7 +4,7 @@ module "label" {
 }
 
 resource "aws_lambda_function" "autospotting" {
-  count = var.lambda_zipname != "" ? 0 : 1
+  count = var.lambda_zipname == "" ? 0 : 1
 
   function_name    = module.label.id
   filename         = var.lambda_zipname


### PR DESCRIPTION
the module tried to create the lambda function when `lambda_zipname` is empty (default), which will return an error on line 11:
```
Error: Error in function call

  on .terraform/modules/autospotting/modules/lambda/main.tf line 11, in resource "aws_lambda_function" "autospotting":
  11:   source_code_hash = filebase64sha256(var.lambda_zipname)
    |----------------
    | var.lambda_zipname is ""
```
I think this is a bug. Let me know if I'm using the module wrongly