### PR TITLE
refactor: Use nullable attributes instead of zero-count resources

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -4,11 +4,11 @@ module "label" {
 }
 
 resource "aws_lambda_function" "autospotting" {
-  count = var.lambda_zipname != "" ? 0 : 1
-
   function_name    = module.label.id
   filename         = var.lambda_zipname
-  source_code_hash = filebase64sha256(var.lambda_zipname)
+  source_code_hash = var.lambda_zipname == null ? null : filebase64sha256(var.lambda_zipname)
+  s3_bucket        = var.lambda_zipname == null ? var.lambda_s3_bucket : null
+  s3_key           = var.lambda_zipname == null ? var.lambda_s3_key : null
   role             = var.lambda_role_arn
   runtime          = var.lambda_runtime
   timeout          = var.lambda_timeout
@@ -34,36 +34,3 @@ resource "aws_lambda_function" "autospotting" {
     }
   }
 }
-
-resource "aws_lambda_function" "autospotting_from_s3" {
-  count = var.lambda_zipname != "" ? 0 : 1
-
-  function_name = module.label.id
-  s3_bucket     = var.lambda_s3_bucket
-  s3_key        = var.lambda_s3_key
-  role          = var.lambda_role_arn
-  runtime       = var.lambda_runtime
-  timeout       = var.lambda_timeout
-  handler       = "AutoSpotting"
-  memory_size   = var.lambda_memory_size
-  tags          = merge(var.lambda_tags, module.label.tags)
-
-  environment {
-    variables = {
-      ALLOWED_INSTANCE_TYPES       = var.autospotting_allowed_instance_types
-      DISALLOWED_INSTANCE_TYPES    = var.autospotting_disallowed_instance_types
-      INSTANCE_TERMINATION_METHOD  = var.autospotting_instance_termination_method
-      MIN_ON_DEMAND_NUMBER         = var.autospotting_min_on_demand_number
-      MIN_ON_DEMAND_PERCENTAGE     = var.autospotting_min_on_demand_percentage
-      ON_DEMAND_PRICE_MULTIPLIER   = var.autospotting_on_demand_price_multiplier
-      SPOT_PRICE_BUFFER_PERCENTAGE = var.autospotting_spot_price_buffer_percentage
-      SPOT_PRODUCT_DESCRIPTION     = var.autospotting_spot_product_description
-      BIDDING_POLICY               = var.autospotting_bidding_policy
-      REGIONS                      = var.autospotting_regions_enabled
-      TAG_FILTERS                  = var.autospotting_tag_filters
-      TAG_FILTERING_MODE           = var.autospotting_tag_filtering_mode
-      LICENSE                      = var.autospotting_license
-    }
-  }
-}
-

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -1,22 +1,7 @@
 output "function_name" {
-  value = element(
-    concat(
-      aws_lambda_function.autospotting.*.function_name,
-      aws_lambda_function.autospotting_from_s3.*.function_name,
-      [""],
-    ),
-    0,
-  )
+  value = aws_lambda_function.autospotting.function_name
 }
 
 output "arn" {
-  value = element(
-    concat(
-      aws_lambda_function.autospotting.*.arn,
-      aws_lambda_function.autospotting_from_s3.*.arn,
-      [""],
-    ),
-    0,
-  )
+  value = aws_lambda_function.autospotting.arn
 }
-

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -1,13 +1,13 @@
 variable "lambda_zipname" {
-  default = ""
+  default = null
 }
 
 variable "lambda_s3_bucket" {
-  default = ""
+  default = null
 }
 
 variable "lambda_s3_key" {
-  default = ""
+  default = null
 }
 
 variable "lambda_role_arn" {}

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ EOF
 # Lambda configuration
 variable "lambda_zipname" {
   description = "Name of the archive, relative to the module"
-  default     = ""
+  default     = null
 }
 
 variable "lambda_s3_bucket" {


### PR DESCRIPTION
Terraform 0.12 introduced nullable attributes, so the module can now use a single lambda resource with selective attributes instead of 2 mostly redundant resources.

This PR also fixes (and should probably but not necessarily supercede) #20 