### PR TITLE
Feature completeness catch-up/sync with CloudFormation

### DIFF
--- a/autospotting-policy.json
+++ b/autospotting-policy.json
@@ -5,14 +5,19 @@
       "Action": [
         "autoscaling:AttachInstances",
         "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "autoscaling:DetachInstances",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup",
+        "autoscaling:DescribeLifecycleHooks",
+        "cloudformation:Describe*",
         "ec2:CreateTags",
+        "ec2:DeleteTags",
         "ec2:DescribeInstanceAttribute",
         "ec2:DescribeInstances",
+        "ec2:DescribeLaunchTemplateVersions",
         "ec2:DescribeRegions",
         "ec2:DescribeSpotPriceHistory",
         "ec2:RunInstances",
@@ -21,8 +26,7 @@
         "iam:PassRole",
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "cloudformation:DescribeStacks"
+        "logs:PutLogEvents"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/main.tf
+++ b/main.tf
@@ -95,3 +95,10 @@ resource "aws_iam_policy" "beanstalk_policy" {
   name   = "elastic_beanstalk_iam_policy_for_${module.label.id}"
   policy = data.aws_iam_policy_document.beanstalk.json
 }
+
+# Regional resources that trigger the main Lambda function
+
+module "regional" {
+  source                  = "./modules/regional"
+  autospotting_lambda_arn = module.aws_lambda_function.arn
+}

--- a/main.tf
+++ b/main.tf
@@ -76,3 +76,22 @@ resource "aws_cloudwatch_log_group" "log_group_autospotting" {
   retention_in_days = 7
 }
 
+# Elastic Beanstalk policy
+
+data "aws_iam_policy_document" "beanstalk" {
+  statement {
+    actions = [
+      "cloudformation:DescribeStackResource",
+      "cloudformation:DescribeStackResources",
+      "cloudformation:SignalResource",
+      "cloudformation:RegisterListener",
+      "cloudformation:GetListenerCredentials"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "beanstalk_policy" {
+  name   = "elastic_beanstalk_iam_policy_for_${module.label.id}"
+  policy = data.aws_iam_policy_document.beanstalk.json
+}

--- a/modules/regional/generate.go
+++ b/modules/regional/generate.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func check(e error) {
+	if e != nil {
+		fmt.Println(e.Error())
+		panic(e)
+	}
+}
+
+// getRegions generates a list of AWS regions.
+func getRegions() ([]string, error) {
+	var output []string
+
+	fmt.Println("Scanning for available AWS regions")
+
+	sess, err := session.NewSession()
+	check(err)
+
+	ec2client := ec2.New(sess, aws.NewConfig().WithRegion(endpoints.UsEast1RegionID))
+	resp, err := ec2client.DescribeRegions(&ec2.DescribeRegionsInput{})
+
+	check(err)
+
+	fmt.Println(resp)
+
+	for _, r := range resp.Regions {
+
+		if r != nil && r.RegionName != nil {
+			fmt.Println("Found region", *r.RegionName)
+			output = append(output, *r.RegionName)
+		}
+	}
+	return output, nil
+}
+
+func main() {
+
+	f, err := os.Create("regional.tf")
+	check(err)
+	defer f.Close()
+
+	t, err := template.ParseFiles("regional.tf.template.gohtml")
+	check(err)
+
+	regions, err := getRegions()
+	check(err)
+
+	sort.Slice(regions,
+		func(i, j int) bool {
+			return regions[i] < regions[j]
+		})
+
+	err = t.Execute(f, regions)
+	check(err)
+
+}

--- a/modules/regional/go.mod
+++ b/modules/regional/go.mod
@@ -1,0 +1,5 @@
+module github.com/AutoSpotting/terraform-aws-autospotting
+
+go 1.14
+
+require github.com/aws/aws-sdk-go v1.30.7 // indirect

--- a/modules/regional/go.sum
+++ b/modules/regional/go.sum
@@ -1,0 +1,16 @@
+github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY=
+github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/modules/regional/main.tf
+++ b/modules/regional/main.tf
@@ -1,0 +1,22 @@
+
+variable "autospotting_lambda_arn" {}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}

--- a/modules/regional/regional.tf
+++ b/modules/regional/regional.tf
@@ -1,0 +1,116 @@
+# This file is generated, do not edit it directly.
+# To update it execute "go run generate.go"
+
+
+module "regional_resources_ap-northeast-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "ap-northeast-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_ap-northeast-2" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "ap-northeast-2"
+    source                  = "./resources"
+}
+
+module "regional_resources_ap-south-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "ap-south-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_ap-southeast-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "ap-southeast-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_ap-southeast-2" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "ap-southeast-2"
+    source                  = "./resources"
+}
+
+module "regional_resources_ca-central-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "ca-central-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_eu-central-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "eu-central-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_eu-north-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "eu-north-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_eu-west-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "eu-west-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_eu-west-2" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "eu-west-2"
+    source                  = "./resources"
+}
+
+module "regional_resources_eu-west-3" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "eu-west-3"
+    source                  = "./resources"
+}
+
+module "regional_resources_sa-east-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "sa-east-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_us-east-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "us-east-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_us-east-2" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "us-east-2"
+    source                  = "./resources"
+}
+
+module "regional_resources_us-west-1" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "us-west-1"
+    source                  = "./resources"
+}
+
+module "regional_resources_us-west-2" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "us-west-2"
+    source                  = "./resources"
+}
+

--- a/modules/regional/regional.tf.template.gohtml
+++ b/modules/regional/regional.tf.template.gohtml
@@ -1,0 +1,11 @@
+# This file is generated, do not edit it directly.
+# To update it execute "go run generate.go"
+
+{{range $index, $region := .}}
+module "regional_resources_{{$region}}" {
+    autospotting_lambda_arn = var.autospotting_lambda_arn
+    lambda_iam_role         = aws_iam_role.iam_for_lambda
+    region                  = "{{$region}}"
+    source                  = "./resources"
+}
+{{end}}

--- a/modules/regional/resources/.gitignore
+++ b/modules/regional/resources/.gitignore
@@ -1,0 +1,1 @@
+lambda.zip

--- a/modules/regional/resources/handler.py
+++ b/modules/regional/resources/handler.py
@@ -1,0 +1,36 @@
+from boto3 import client
+from json import dumps
+from os import environ
+from sys import exc_info
+from traceback import print_exc
+
+lambda_arn = (environ['AUTOSPOTTING_LAMBDA_ARN'])
+
+def parse_region_from_arn(arn):
+    return arn.split(':')[3]
+
+def handler(event, context):
+    snsEvent = {
+        'Records': [
+            {
+                'Event': 'aws:sns',
+                'EventSource': '1.0',
+                'EventSubscriptionArn': 'arn:aws:sns:' + event['region'] + ':FakeAccountId:FakeTopic',
+                'Sns': {
+                    'Type': 'Notification',
+                    'Message': dumps(event),
+                }
+            }
+        ]
+    }
+    try:
+        svc = client('lambda', region_name=parse_region_from_arn(lambda_arn))
+        response = svc.invoke(
+            FunctionName=lambda_arn,
+            LogType='Tail',
+            Payload=dumps(snsEvent),
+        )
+        print(response)
+    except:
+        print_exc()
+        print("Unexpected error:", exc_info()[0])

--- a/modules/regional/resources/main.tf
+++ b/modules/regional/resources/main.tf
@@ -1,0 +1,60 @@
+
+provider "aws" {
+  version = "~> 2.0"
+  region  = var.region
+}
+
+resource "aws_cloudwatch_event_rule" "autospotting_regional_event_capture" {
+  name        = "autospotting_regional_event_capture"
+  description = "Capture relevant events that are only fired within AWS regions and need to be forwarded to the central Lambda function"
+
+  event_pattern = <<PATTERN
+{
+  "detail-type": [
+    "EC2 Spot Instance Interruption Warning"
+  ],
+  "source": [
+    "aws.ec2"
+  ]
+}
+PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "lambda" {
+  rule = aws_cloudwatch_event_rule.autospotting_regional_event_capture.name
+  arn  = aws_lambda_function.regional_lambda.arn
+}
+
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  output_path = "${path.module}/lambda.zip"
+  source_file = "${path.module}/handler.py"
+}
+
+resource "aws_lambda_function" "regional_lambda" {
+  filename      = data.archive_file.lambda_zip.output_path
+  function_name = "autospotting_regional_lambda"
+  role          = var.lambda_iam_role.arn
+  handler       = "handler.handler"
+
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+
+  runtime = "python3.7"
+  timeout = 300
+
+  environment {
+    variables = {
+      AUTOSPOTTING_LAMBDA_ARN = var.autospotting_lambda_arn
+    }
+  }
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.regional_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.autospotting_regional_event_capture.arn
+}
+
+

--- a/modules/regional/resources/variables.tf
+++ b/modules/regional/resources/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {}
+variable "autospotting_lambda_arn" {}
+variable "lambda_iam_role" {}


### PR DESCRIPTION
Implements some of the missing functionality currently available when using CloudFormation.

For now we have:
- spot termination notification handling
- IAM policy for Beanstalk

Further review of the CloudFormation code is needed to see if we have any other differences.

Needs testing, none did so far.

Fixes #11.