### PR TITLE
Allow describe ASG instances

### DIFF
--- a/autospotting-policy.json
+++ b/autospotting-policy.json
@@ -5,6 +5,7 @@
       "Action": [
         "autoscaling:AttachInstances",
         "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
         "autoscaling:DetachInstances",


### PR DESCRIPTION
This permission is needed by the AutoSpotting main lambda function. It allows the function to remove interrupted spot instances following the cloudwatch event notifications

```
spot_termination.go:222: Failed get ASG name for <instance-id> with err: AccessDenied: User: <lambda_assumed_role_arn> is not authorized to perform: autoscaling:DescribeAutoScalingInstances
```