### PR TITLE
(fix): update policy to describe launch templates

### DIFF
--- a/autospotting-policy.json
+++ b/autospotting-policy.json
@@ -22,7 +22,9 @@
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents",
-        "cloudformation:DescribeStacks"
+        "cloudformation:DescribeStacks",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions"
       ],
       "Effect": "Allow",
       "Resource": "*"


### PR DESCRIPTION
At the moment, Autospotting cannot describe launch templates and fails with below error. My use case was a [eks_node_group](https://www.terraform.io/docs/providers/aws/r/eks_node_group.html) terraform resource

```bash
2020/05/04 08:12:05 instance.go:528: Failed to describe launch template lt-0c7795fa76d604b65 version 1 encountered error: UnauthorizedOperation: You are not authorized to perform this operation.
```

This fixes https://github.com/AutoSpotting/terraform-aws-autospotting/issues/26

Signed-off-by: Vikas Kumar <vikas@reachvikas.com>