### PR TITLE
Changing the regional policy name.

### DIFF
--- a/modules/regional/main.tf
+++ b/modules/regional/main.tf
@@ -1,8 +1,10 @@
-
-variable "autospotting_lambda_arn" {}
+module "label" {
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.13.0"
+  context = var.label_context
+}
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda"
+  name = "${module.label.id}-iam_for_lambda"
 
   assume_role_policy = <<EOF
 {

--- a/modules/regional/variables.tf
+++ b/modules/regional/variables.tf
@@ -1,0 +1,32 @@
+variable "autospotting_lambda_arn" {}
+
+# Label configuration
+variable "label_context" {
+  description = "Used to pass in label module context"
+  type        = object({
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    enabled             = bool
+    delimiter           = string
+    attributes          = list(string)
+    label_order         = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+  })
+  default     = {
+    namespace           = ""
+    environment         = ""
+    stage               = ""
+    name                = ""
+    enabled             = true
+    delimiter           = ""
+    attributes          = []
+    label_order         = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = ""
+  }
+}


### PR DESCRIPTION
Moving this to being a variable as currently
it blocks Autospotting being deployed more
than once.