### PR TITLE
Passing the label context to regional module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,4 +101,5 @@ resource "aws_iam_policy" "beanstalk_policy" {
 module "regional" {
   source                  = "./modules/regional"
   autospotting_lambda_arn = module.aws_lambda_function.arn
+  label_context           = module.label.context
 }


### PR DESCRIPTION
In the last change I did not add passing the
label context to the regional module which
causes the IAM role to have a name of
-iam_for_lambda rather than adding the further
context to make sure it is unique per
environment.