### PR TITLE
Regional lambda name fix

### DIFF
--- a/modules/regional/regional.tf
+++ b/modules/regional/regional.tf
@@ -7,6 +7,7 @@ module "regional_resources_ap-northeast-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "ap-northeast-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_ap-northeast-2" {
@@ -14,6 +15,7 @@ module "regional_resources_ap-northeast-2" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "ap-northeast-2"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_ap-south-1" {
@@ -21,6 +23,7 @@ module "regional_resources_ap-south-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "ap-south-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_ap-southeast-1" {
@@ -28,6 +31,7 @@ module "regional_resources_ap-southeast-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "ap-southeast-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_ap-southeast-2" {
@@ -35,6 +39,7 @@ module "regional_resources_ap-southeast-2" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "ap-southeast-2"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_ca-central-1" {
@@ -42,6 +47,7 @@ module "regional_resources_ca-central-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "ca-central-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_eu-central-1" {
@@ -49,6 +55,7 @@ module "regional_resources_eu-central-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "eu-central-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_eu-north-1" {
@@ -56,6 +63,7 @@ module "regional_resources_eu-north-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "eu-north-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_eu-west-1" {
@@ -63,6 +71,7 @@ module "regional_resources_eu-west-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "eu-west-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_eu-west-2" {
@@ -70,6 +79,7 @@ module "regional_resources_eu-west-2" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "eu-west-2"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_eu-west-3" {
@@ -77,6 +87,7 @@ module "regional_resources_eu-west-3" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "eu-west-3"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_sa-east-1" {
@@ -84,6 +95,7 @@ module "regional_resources_sa-east-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "sa-east-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_us-east-1" {
@@ -91,6 +103,7 @@ module "regional_resources_us-east-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "us-east-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_us-east-2" {
@@ -98,6 +111,7 @@ module "regional_resources_us-east-2" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "us-east-2"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_us-west-1" {
@@ -105,6 +119,7 @@ module "regional_resources_us-west-1" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "us-west-1"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 
 module "regional_resources_us-west-2" {
@@ -112,5 +127,6 @@ module "regional_resources_us-west-2" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "us-west-2"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 

--- a/modules/regional/regional.tf.template.gohtml
+++ b/modules/regional/regional.tf.template.gohtml
@@ -7,5 +7,6 @@ module "regional_resources_{{$region}}" {
     lambda_iam_role         = aws_iam_role.iam_for_lambda
     region                  = "{{$region}}"
     source                  = "./resources"
+    label_id                = module.label.id
 }
 {{end}}

--- a/modules/regional/resources/main.tf
+++ b/modules/regional/resources/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_cloudwatch_event_rule" "autospotting_regional_event_capture" {
-  name        = "${label_id}-autospotting_regional_event_capture"
+  name        = "${var.label_id}-autospotting_regional_event_capture"
   description = "Capture relevant events that are only fired within AWS regions and need to be forwarded to the central Lambda function"
 
   event_pattern = <<PATTERN
@@ -33,7 +33,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_lambda_function" "regional_lambda" {
   filename      = data.archive_file.lambda_zip.output_path
-  function_name = "${label_id}-autospotting_regional_lambda"
+  function_name = "${var.label_id}-autospotting_regional_lambda"
   role          = var.lambda_iam_role.arn
   handler       = "handler.handler"
 
@@ -50,7 +50,7 @@ resource "aws_lambda_function" "regional_lambda" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {
-  statement_id  = "${label_id}-AllowExecutionFromCloudWatch"
+  statement_id  = "${var.label_id}-AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.regional_lambda.function_name
   principal     = "events.amazonaws.com"

--- a/modules/regional/resources/main.tf
+++ b/modules/regional/resources/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_cloudwatch_event_rule" "autospotting_regional_event_capture" {
-  name        = "${var.label_id}-autospotting_regional_event_capture"
+  name        = "${var.label_id}-regional_events"
   description = "Capture relevant events that are only fired within AWS regions and need to be forwarded to the central Lambda function"
 
   event_pattern = <<PATTERN
@@ -33,7 +33,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_lambda_function" "regional_lambda" {
   filename      = data.archive_file.lambda_zip.output_path
-  function_name = "${var.label_id}-autospotting_regional_lambda"
+  function_name = "${var.label_id}-regional_lambda"
   role          = var.lambda_iam_role.arn
   handler       = "handler.handler"
 

--- a/modules/regional/resources/main.tf
+++ b/modules/regional/resources/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_cloudwatch_event_rule" "autospotting_regional_event_capture" {
-  name        = "autospotting_regional_event_capture"
+  name        = "${label_id}-autospotting_regional_event_capture"
   description = "Capture relevant events that are only fired within AWS regions and need to be forwarded to the central Lambda function"
 
   event_pattern = <<PATTERN
@@ -33,7 +33,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_lambda_function" "regional_lambda" {
   filename      = data.archive_file.lambda_zip.output_path
-  function_name = "autospotting_regional_lambda"
+  function_name = "${label_id}-autospotting_regional_lambda"
   role          = var.lambda_iam_role.arn
   handler       = "handler.handler"
 
@@ -50,7 +50,7 @@ resource "aws_lambda_function" "regional_lambda" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "${label_id}-AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.regional_lambda.function_name
   principal     = "events.amazonaws.com"

--- a/modules/regional/resources/variables.tf
+++ b/modules/regional/resources/variables.tf
@@ -1,3 +1,4 @@
 variable "region" {}
 variable "autospotting_lambda_arn" {}
 variable "lambda_iam_role" {}
+variable "label_id" {}


### PR DESCRIPTION
Further fix to the regional naming.

This has now been deployed in more than one environment in the same account and found to be fully working.