### PR TITLE
upgrade null-label version to 0.18.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.13.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.18.0"
   context     = var.label_context
   namespace   = var.label_namespace
   environment = var.label_environment

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.13.0"
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.18.0"
   context = var.label_context
 }
 

--- a/modules/regional/main.tf
+++ b/modules/regional/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.13.0"
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.18.0"
   context = var.label_context
 }
 


### PR DESCRIPTION
I want to upgrade the dependent module terraform-null-label 
the reason is - I wanted to upgrade my terraform to version 0.13 and the current version of null-label(0.13.0) does not support it

meta usecase:
I wanted to upgrade to terraform 0.13 in order to use autospotting with the count parameter
I have 2 terraform deployments in 2 AZs in the same AWS account that both have the same terrafrom blueprints
and I want to be able to deploy to the main AZ with autospotting count = 1 and to a second AZ with autospotting count = 0
this is only supported in terraform v0.13