### PR TITLE
changed version ref for null-label mabda model to ref original autosp…

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.21.0"
+  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.13.0"
   context = var.label_context
 }
 


### PR DESCRIPTION
…ot module version

updates the tag to use same one we are currently using for the autospotting module (non-upgraded)