### PR TITLE
Allow running v5 AWS provider

### DIFF
--- a/modules/lambda/fargate.tf
+++ b/modules/lambda/fargate.tf
@@ -12,7 +12,7 @@ data "aws_region" "current" {}
 module "vpc" {
   count   = var.use_existing_subnets ? 0 : 1
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.21"
+  version = ">= 5.21.0"
 
   name = "autospotting-${module.label.id}"
 

--- a/modules/lambda/fargate.tf
+++ b/modules/lambda/fargate.tf
@@ -12,7 +12,7 @@ data "aws_region" "current" {}
 module "vpc" {
   count   = var.use_existing_subnets ? 0 : 1
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 5.21.0"
+  version = ">= 5.21.0, < 6.0.0"
 
   name = "autospotting-${module.label.id}"
 

--- a/modules/regional/resources/main.tf
+++ b/modules/regional/resources/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0, < 6"
     }
   }
 }

--- a/modules/regional/resources/main.tf
+++ b/modules/regional/resources/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
Change the AWS provider to v5, and upgrade the VPC module